### PR TITLE
corrects confirm convention

### DIFF
--- a/00_initial.sh
+++ b/00_initial.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "installing the base system - this assumes you have at the partition formatted and mounted as /mnt and internet connection established"
-echo "is all that the case? [Y/N] "
+echo "is all that the case? [Y/n] "
 read yes
 if [[ $yes == "Y" || $yes == "y" || $yes == "" ]]; then
 	pacstrap /mnt base


### PR DESCRIPTION
Not a big deal, but [Y/N] should be [Y/n] if Y is the default option accepted by empty answer.
